### PR TITLE
Release helm-unittest for Linux/ARM64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ dist:
 	mkdir -p $(DIST)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o untt -ldflags $(LDFLAGS) ./main.go
 	tar -zcvf $(DIST)/helm-unittest-linux-$(VERSION).tgz untt README.md LICENSE plugin.yaml
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o untt -ldflags $(LDFLAGS) ./main.go
+	tar -zcvf $(DIST)/helm-unittest-linux-arm64-$(VERSION).tgz untt README.md LICENSE plugin.yaml
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o untt -ldflags $(LDFLAGS) ./main.go
 	tar -zcvf $(DIST)/helm-unittest-macos-$(VERSION).tgz untt README.md LICENSE plugin.yaml
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o untt.exe -ldflags $(LDFLAGS) ./main.go

--- a/install-binary.sh
+++ b/install-binary.sh
@@ -51,7 +51,7 @@ initOS() {
 # verifySupported checks that the os/arch combination is supported for
 # binary builds.
 verifySupported() {
-  local supported="linux-amd64\nmacos-amd64\nwindows-amd64"
+  local supported="linux-arm64\nlinux-amd64\nmacos-amd64\nwindows-amd64"
   if ! echo "${supported}" | grep -q "${OS}-${ARCH}"; then
     echo "No prebuild binary for ${OS}-${ARCH}."
     exit 1
@@ -75,7 +75,9 @@ getDownloadURL() {
     exit 1
   fi
   echo "Version: ${version}"
-  DOWNLOAD_URL="https://github.com/${PROJECT_GH}/releases/download/${version}/${PROJECT_NAME}-${OS}-${version}.tgz"
+  if [ `uname -m` == "aarch64" ] ; then DOWNLOAD_URL="https://github.com/${PROJECT_GH}/releases/download/${version}/${PROJECT_NAME}-${OS}-arm64-${version}.tgz";
+  else DOWNLOAD_URL="https://github.com/${PROJECT_GH}/releases/download/${version}/${PROJECT_NAME}-${OS}-${version}.tgz";
+  fi
   echo "Download URL: ${DOWNLOAD_URL}"
 }
 


### PR DESCRIPTION
1. Added Linux/ARM64 to the Makefile for releasing Linux/ARM64 binary.
2. Added "linux-arm64" in the OS/ARCH checks in verifySupported() function, and added arm64 to the DOWNLOAD_URL in getDownloadURL() function, in install-binary.sh file.

Signed-off-by: odidev <odidev@puresoftware.com>